### PR TITLE
Standardize Querying

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,15 @@
             "email": "dev@rebelcode.com"
         }
     ],
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": {
+            "RebelCode\\Diary\\": "src/"
+        }
+    },
     "require": {
-        "php": "^5.3 | ^7.0"
+        "php": "^5.3 | ^7.0",
+        "dhii/espresso-boolean-expression-interface": "dev-master"
     },
     "require-dev": {
         "dhii/php-cs-fixer-config": "dev-php-5.3",
@@ -18,10 +25,10 @@
         "ptrofimov/xpmock": "^1.1",
         "codeclimate/php-test-reporter": "^0.3.2"
     },
-    "minimum-stability": "dev",
-    "autoload": {
-        "psr-4": {
-            "RebelCode\\Diary\\": "src/"
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/espresso-boolean-expression-interface"
         }
-    }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,18 @@
         {
             "type": "vcs",
             "url": "https://github.com/Dhii/espresso-boolean-expression-interface"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/espresso-interface.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/evaluable-interface.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/Dhii/data-key-value-aware-interface"
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,184 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6daea054e783e61c56aacaf254f17ed3",
-    "content-hash": "048d703546877501a270c6ecf07498aa",
-    "packages": [],
+    "hash": "f283dcec63f56da585c0cbfa766e53e5",
+    "content-hash": "4bb807bb51776e00dd1dbda6812eae1e",
+    "packages": [
+        {
+            "name": "dhii/data-key-value-aware-interface",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/data-key-value-aware-interface.git",
+                "reference": "d33ab79289415afe67ebf98005821459182bbf20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/data-key-value-aware-interface/zipball/d33ab79289415afe67ebf98005821459182bbf20",
+                "reference": "d33ab79289415afe67ebf98005821459182bbf20",
+                "shasum": ""
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "4.*",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Data\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "An interface for value objects",
+            "support": {
+                "source": "https://github.com/Dhii/data-key-value-aware-interface/tree/master",
+                "issues": "https://github.com/Dhii/data-key-value-aware-interface/issues"
+            },
+            "time": "2016-11-26 19:07:12"
+        },
+        {
+            "name": "dhii/espresso-boolean-expression-interface",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/espresso-boolean-expression-interface.git",
+                "reference": "0ad1f28960f34189d25911dcaab8607f8ad00a72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/espresso-boolean-expression-interface/zipball/0ad1f28960f34189d25911dcaab8607f8ad00a72",
+                "reference": "0ad1f28960f34189d25911dcaab8607f8ad00a72",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/espresso-interface": "dev-master",
+                "php": "^5.3.9 | ^7.0"
+            },
+            "require-dev": {
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "libary",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Espresso\\": "src/"
+                }
+            },
+            "authors": [
+                {
+                    "name": "Dhii",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interfaces for Espresso boolean expressions.",
+            "support": {
+                "source": "https://github.com/Dhii/espresso-boolean-expression-interface/tree/master",
+                "issues": "https://github.com/Dhii/espresso-boolean-expression-interface/issues"
+            },
+            "time": "2016-12-24 10:03:13"
+        },
+        {
+            "name": "dhii/espresso-interface",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/espresso-interface.git",
+                "reference": "280b5601e12e3bcef5e08a39c444232b6065d9c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/espresso-interface/zipball/280b5601e12e3bcef5e08a39c444232b6065d9c7",
+                "reference": "280b5601e12e3bcef5e08a39c444232b6065d9c7",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/evaluable-interface": "dev-master",
+                "php": "^5.3.9 | ^7.0"
+            },
+            "require-dev": {
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Espresso\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "The interfaces for Espresso.",
+            "support": {
+                "source": "https://github.com/Dhii/espresso-interface/tree/master",
+                "issues": "https://github.com/Dhii/espresso-interface/issues"
+            },
+            "time": "2016-12-26 14:49:46"
+        },
+        {
+            "name": "dhii/evaluable-interface",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/evaluable-interface.git",
+                "reference": "304dfb73c264f9e192ca95483130f848cb880c97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/evaluable-interface/zipball/304dfb73c264f9e192ca95483130f848cb880c97",
+                "reference": "304dfb73c264f9e192ca95483130f848cb880c97",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/data-key-value-aware-interface": "dev-master",
+                "php": "^5.3.9 | ^7.0"
+            },
+            "require-dev": {
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Evaluable\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "An interface for an object that can be evaluated.",
+            "support": {
+                "source": "https://github.com/Dhii/evaluable-interface/tree/master",
+                "issues": "https://github.com/Dhii/evaluable-interface/issues"
+            },
+            "time": "2016-12-26 15:25:15"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",
@@ -1430,12 +1605,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "6078a2d455994608fa866ccebc739af08db4b961"
+                "reference": "0d2407bc99e5617a72be5309398f2c3062432f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/6078a2d455994608fa866ccebc739af08db4b961",
-                "reference": "6078a2d455994608fa866ccebc739af08db4b961",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0d2407bc99e5617a72be5309398f2c3062432f3c",
+                "reference": "0d2407bc99e5617a72be5309398f2c3062432f3c",
                 "shasum": ""
             },
             "require": {
@@ -1478,7 +1653,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-19 15:48:05"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/console",
@@ -1486,12 +1661,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "de0a69cc9f3f8654e6b5d370e66ae8f2c81fd954"
+                "reference": "6f1ee11b773245ddf18cfef9aa6aa491566f506f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/de0a69cc9f3f8654e6b5d370e66ae8f2c81fd954",
-                "reference": "de0a69cc9f3f8654e6b5d370e66ae8f2c81fd954",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6f1ee11b773245ddf18cfef9aa6aa491566f506f",
+                "reference": "6f1ee11b773245ddf18cfef9aa6aa491566f506f",
                 "shasum": ""
             },
             "require": {
@@ -1539,7 +1714,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-19 15:38:44"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/debug",
@@ -1547,12 +1722,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "49dea9f77db1e91a2c6c892f9883b9b6ef2018b3"
+                "reference": "0c4933bda12eaf3fb985d03ac46d8b28507024ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/49dea9f77db1e91a2c6c892f9883b9b6ef2018b3",
-                "reference": "49dea9f77db1e91a2c6c892f9883b9b6ef2018b3",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0c4933bda12eaf3fb985d03ac46d8b28507024ec",
+                "reference": "0c4933bda12eaf3fb985d03ac46d8b28507024ec",
                 "shasum": ""
             },
             "require": {
@@ -1596,7 +1771,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-19 15:48:05"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1604,12 +1779,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "bbefd025bec36f17cc57df418ba488f43e5e28e9"
+                "reference": "47ab31840feed40355e149a1519c1a2dcb797cf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bbefd025bec36f17cc57df418ba488f43e5e28e9",
-                "reference": "bbefd025bec36f17cc57df418ba488f43e5e28e9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/47ab31840feed40355e149a1519c1a2dcb797cf0",
+                "reference": "47ab31840feed40355e149a1519c1a2dcb797cf0",
                 "shasum": ""
             },
             "require": {
@@ -1656,7 +1831,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-19 15:48:05"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/filesystem",
@@ -1713,12 +1888,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775"
+                "reference": "e7062df114ba5771c13ddf748cd486389a4bd605"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/c0f10576335743b881ac1ed39d18c0fa66048775",
-                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e7062df114ba5771c13ddf748cd486389a4bd605",
+                "reference": "e7062df114ba5771c13ddf748cd486389a4bd605",
                 "shasum": ""
             },
             "require": {
@@ -1754,7 +1929,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-13 09:38:12"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1821,12 +1996,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "5e180b2c8f0341308cbb3de3831861f08bcb2b60"
+                "reference": "b8824a344b62b7db05df2a609a664cfadbba876b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/5e180b2c8f0341308cbb3de3831861f08bcb2b60",
-                "reference": "5e180b2c8f0341308cbb3de3831861f08bcb2b60",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b8824a344b62b7db05df2a609a664cfadbba876b",
+                "reference": "b8824a344b62b7db05df2a609a664cfadbba876b",
                 "shasum": ""
             },
             "require": {
@@ -1862,7 +2037,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-19 16:17:38"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/stopwatch",
@@ -1870,12 +2045,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "35bae476693150728b0eb51647faac82faf9aaca"
+                "reference": "3c6a9c78905856af57052570f8c95818daa24533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/35bae476693150728b0eb51647faac82faf9aaca",
-                "reference": "35bae476693150728b0eb51647faac82faf9aaca",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/3c6a9c78905856af57052570f8c95818daa24533",
+                "reference": "3c6a9c78905856af57052570f8c95818daa24533",
                 "shasum": ""
             },
             "require": {
@@ -1911,7 +2086,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:29:29"
+            "time": "2016-12-27 10:39:57"
         },
         {
             "name": "symfony/yaml",
@@ -1966,6 +2141,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "dhii/espresso-boolean-expression-interface": 20,
         "dhii/php-cs-fixer-config": 20
     },
     "prefer-stable": false,

--- a/src/DiaryInterface.php
+++ b/src/DiaryInterface.php
@@ -2,6 +2,8 @@
 
 namespace RebelCode\Diary;
 
+use \RebelCode\Diary\Query\BookingQueryInterface;
+
 /**
  * Represents the hub of the Diary library.
  *
@@ -25,11 +27,11 @@ interface DiaryInterface
      *
      * @since [*next-version*]
      *
-     * @param mixed $query The query.
+     * @param BookingQueryInterface $query The query instance.
      *
      * @return BookingInterface[] An array of booking instances that match the given query.
      */
-    public function queryBookings($query);
+    public function queryBookings(BookingQueryInterface $query);
 
     /**
      * Inserts the given booking into storage.

--- a/src/DiaryInterface.php
+++ b/src/DiaryInterface.php
@@ -2,7 +2,7 @@
 
 namespace RebelCode\Diary;
 
-use \RebelCode\Diary\Query\BookingQueryInterface;
+use RebelCode\Diary\Query\BookingQueryInterface;
 
 /**
  * Represents the hub of the Diary library.

--- a/src/Query/BookingConditionInterface.php
+++ b/src/Query/BookingConditionInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RebelCode\Diary\Query;
+
+use Dhii\Espresso\BooleanExpressionInterface;
+
+/**
+ * An object that represents a booking query condition.
+ *
+ * @since [*next-version*]
+ */
+interface BookingConditionInterface extends BooleanExpressionInterface
+{
+}

--- a/src/Query/BookingQueryInterface.php
+++ b/src/Query/BookingQueryInterface.php
@@ -12,7 +12,9 @@ interface BookingQueryInterface
     /**
      * Gets the query condition.
      *
-     * @return \Dhii\Espresso\BooleanExpressionInterface
+     * @since [*next-version*]
+     *
+     * @return BookingConditionInterface
      */
     public function getCondition();
 }

--- a/src/Query/BookingQueryInterface.php
+++ b/src/Query/BookingQueryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace RebelCode\Diary\Query;
+
+/**
+ * Any object that can describe a bookings query.
+ *
+ * @since [*next-version*]
+ */
+interface BookingQueryInterface
+{
+    /**
+     * Gets the query condition.
+     *
+     * @return \Dhii\Espresso\BooleanExpressionInterface
+     */
+    public function getCondition();
+}

--- a/src/Query/Condition/BookingPropertyTermInterface.php
+++ b/src/Query/Condition/BookingPropertyTermInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RebelCode\Diary\Query\Condition;
+
+/**
+ * An entity property evaluable term  that is specific to booking entities.
+ *
+ * @since [*next-version*]
+ */
+interface BookingPropertyTermInterface extends EntityPropertyTermInterface
+{
+}

--- a/src/Query/Condition/EntityPropertyTermInterface.php
+++ b/src/Query/Condition/EntityPropertyTermInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace RebelCode\Diary\Query\Condition;
+
+/**
+ * An evaluable term that represents a property of a storage entity.
+ *
+ * @since [*next-version*]
+ */
+interface EntityPropertyTermInterface extends \Dhii\Evaluable\EvaluableInterface
+{
+    /**
+     * Gets the name of the entity.
+     *
+     * @since [*next-version*]
+     *
+     * @return string The entity identifier.
+     */
+    public function getEntity();
+
+    /**
+     * Gets the name of the property.
+     *
+     * @since [*next-version*]
+     *
+     * @return string The property identifier.
+     */
+    public function getProperty();
+}

--- a/test/functional/Query/BookingConditionInterfaceTest.php
+++ b/test/functional/Query/BookingConditionInterfaceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace RebelCode\Diary\Query\Test;
+
+/**
+ * Tests {@see \RebelCode\Diary\Query\BookingConditionInterface}.
+ *
+ * @since [*next-version*]
+ */
+class BookingConditionInterfaceTest extends \Xpmock\TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\\Diary\\Query\\BookingConditionInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \RebelCode\Diary\Query\BookingConditionInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->evaluate()
+            ->getTerms()
+            ->isNegated()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @covers \RebelCode\Diary\Query\BookingConditionInterface
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+        $this->assertInstanceOf('Dhii\\Espresso\\BooleanExpressionInterface', $subject);
+    }
+}

--- a/test/functional/Query/BookingQueryInterfaceTest.php
+++ b/test/functional/Query/BookingQueryInterfaceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace RebelCode\Diary\Test;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \RebelCode\Diary\Query\BookingQueryInterface}.
+ *
+ * @since [*next-version*]
+ */
+class BookingQueryInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\\Diary\\Query\\BookingQueryInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \RebelCode\Diary\Query\BookingQueryInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->getCondition()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @covers \RebelCode\Diary\Query\BookingQueryInterface
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+    }
+}

--- a/test/functional/Query/Condition/BookingPropertyTermInterfaceTest.php
+++ b/test/functional/Query/Condition/BookingPropertyTermInterfaceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace RebelCode\Diary\Query\Condition\Test;
+
+use RebelCode\Diary\Query\Condition\BookingPropertyTermInterface;
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \RebelCode\Diary\Query\Condition\BookingPropertyTermInterface}.
+ *
+ * @since [*next-version*]
+ */
+class BookingPropertyTermInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\\Diary\\Query\\Condition\\BookingPropertyTermInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return BookingPropertyTermInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->evaluate()
+            ->getEntity()
+            ->getProperty()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @covers \RebelCode\Diary\Query\Condition\BookingPropertyTermInterface
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+        $this->assertInstanceOf('\\RebelCode\\Diary\\Query\\Condition\\EntityPropertyTermInterface', $subject);
+        $this->assertInstanceOf('\\Dhii\\Evaluable\\EvaluableInterface', $subject);
+    }
+}

--- a/test/functional/Query/Condition/EntityPropertyTermInterfaceTest.php
+++ b/test/functional/Query/Condition/EntityPropertyTermInterfaceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace RebelCode\Diary\Query\Condition\Test;
+
+use RebelCode\Diary\Query\Condition\EntityPropertyTermInterface;
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \RebelCode\Diary\Query\Condition\EntityPropertyTermInterface}.
+ *
+ * @since [*next-version*]
+ */
+class EntityPropertyTermInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'RebelCode\\Diary\\Query\\Condition\\EntityPropertyTermInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return EntityPropertyTermInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->evaluate()
+            ->getEntity()
+            ->getProperty()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @covers \RebelCode\Diary\Query\Condition\EntityPropertyTermInterface
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+        $this->assertInstanceOf('\\Dhii\\Evaluable\\EvaluableInterface', $subject);
+    }
+}


### PR DESCRIPTION
## The Problem

Currently, the [querying mechanism][1] is not standardized. This loose mechanism does not allow interoperability between query implementations making the API dependent on the implementation. Furthermore, it shifts more work to the implementation by imposing type checking and validation on given queries since type hinting is not available.

## Proposed Solution

Create a `BookingQueryInterface`. The purpose of this interface will be to outline the booking criteria that is needed for a query to be able to retrieve bookings. This should be as generic as possible so as to allow any form of implementation to be built on top of it.

[1]: https://github.com/RebelCodecom/diary-interface/blob/master/src/DiaryInterface.php#L32